### PR TITLE
Endrer responseType på generert pdf og setter inline på content-disposition.

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
@@ -55,7 +55,7 @@ class SøknadController(
         val decodetFilnavn = URLDecoder.decode(filnavn, StandardCharsets.UTF_8.toString())
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$decodetFilnavn.pdf")
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=$decodetFilnavn.pdf")
                 .contentLength(resource.byteArray.size.toLong())
                 .body(resource)
     }

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
@@ -42,7 +42,7 @@ class SøknadController(
         return søknadService.hentSøknad(søknadId)
     }
 
-    @GetMapping("$SØKNAD/{søknadId}/arbeidsgivermelding", produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
+    @GetMapping("$SØKNAD/{søknadId}/arbeidsgivermelding", produces = [MediaType.APPLICATION_PDF_VALUE])
     @Protected
     @ResponseStatus(OK)
     fun lastNedArbeidsgivermelding(
@@ -55,7 +55,7 @@ class SøknadController(
         val decodetFilnavn = URLDecoder.decode(filnavn, StandardCharsets.UTF_8.toString())
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "filename=$decodetFilnavn.pdf")
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$decodetFilnavn.pdf")
                 .contentLength(resource.byteArray.size.toLong())
                 .body(resource)
     }

--- a/src/test/kotlin/no/nav/sifinnsynapi/common/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/common/SøknadControllerTest.kt
@@ -290,13 +290,13 @@ class SøknadControllerTest {
                 .get(URI(URLDecoder.decode("$SØKNAD/${UUID.randomUUID()}/arbeidsgivermelding", Charset.defaultCharset())))
                 .queryParam("organisasjonsnummer", "12345678")
                 .queryParam("filnavn", forventetFilnavn)
-                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                .accept(MediaType.APPLICATION_PDF_VALUE)
                 .cookie(Cookie("selvbetjening-idtoken", mockOAuth2Server.hentToken().serialize()))
         )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk)
             .andExpect(header().exists(CONTENT_DISPOSITION))
-            .andExpect(header().string(CONTENT_DISPOSITION, "filename=$forventetFilnavn.pdf"))
+            .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$forventetFilnavn.pdf"))
     }
 
     @Test
@@ -311,12 +311,12 @@ class SøknadControllerTest {
                 .get(URI(URLDecoder.decode("$SØKNAD/${UUID.randomUUID()}/arbeidsgivermelding", Charset.defaultCharset())))
                 .queryParam("organisasjonsnummer", "12345678")
                 .queryParam("filnavn", "filnavn%20med%20mellomrom")
-                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                .accept(MediaType.APPLICATION_PDF_VALUE)
                 .cookie(Cookie("selvbetjening-idtoken", mockOAuth2Server.hentToken().serialize()))
         )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk)
             .andExpect(header().exists(CONTENT_DISPOSITION))
-            .andExpect(header().string(CONTENT_DISPOSITION, "filename=$forventetFilnavn.pdf"))
+            .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$forventetFilnavn.pdf"))
     }
 }

--- a/src/test/kotlin/no/nav/sifinnsynapi/common/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/common/SøknadControllerTest.kt
@@ -296,7 +296,7 @@ class SøknadControllerTest {
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk)
             .andExpect(header().exists(CONTENT_DISPOSITION))
-            .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$forventetFilnavn.pdf"))
+            .andExpect(header().string(CONTENT_DISPOSITION, "inline; filename=$forventetFilnavn.pdf"))
     }
 
     @Test
@@ -317,6 +317,6 @@ class SøknadControllerTest {
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk)
             .andExpect(header().exists(CONTENT_DISPOSITION))
-            .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$forventetFilnavn.pdf"))
+            .andExpect(header().string(CONTENT_DISPOSITION, "inline; filename=$forventetFilnavn.pdf"))
     }
 }

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadServiceTest.kt
@@ -43,6 +43,7 @@ internal class SøknadServiceTest {
     @Autowired
     private lateinit var søknadService: SøknadService
 
+
     @Test
     fun hentArbeidsgiverMeldingFil() {
         val søknadId = UUID.randomUUID()


### PR DESCRIPTION
Resulterer i at filen blir åpnet direkte i nettleser uten å åpne en lagrings-dialog.