### PR TITLE
Resetter sak-id på søknader.

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/SifInnsynApiApplication.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/SifInnsynApiApplication.kt
@@ -1,5 +1,8 @@
 package no.nav.sifinnsynapi
 
+import no.nav.sifinnsynapi.soknad.SøknadRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -10,16 +13,37 @@ import org.springframework.retry.annotation.EnableRetry
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
-@SpringBootApplication(exclude = [
-    ErrorMvcAutoConfiguration::class
-])
+@SpringBootApplication(
+    exclude = [
+        ErrorMvcAutoConfiguration::class
+    ]
+)
 @EnableRetry
 @EnableKafka
 @EnableTransactionManagement
 @EnableScheduling
 @ConfigurationPropertiesScan("no.nav.sifinnsynapi")
 @EnableConfigurationProperties
-class SifInnsynApiApplication
+class SifInnsynApiApplication(private val søknadRepository: SøknadRepository) : CommandLineRunner {
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(SifInnsynApiApplication::class.java)
+    }
+
+    // TODO: 11/11/2021 Slettes etter prodsetting
+    /**
+     * Callback used to run the bean.
+     * @param args incoming main method arguments
+     * @throws Exception on error
+     */
+    override fun run(vararg args: String?) {
+        søknadRepository.findAllBySaksIdIsNotNull().map {
+            logger.info("Resetter saksId på søknad med id {} til null.", it.id)
+            val oppdatertSøknad = søknadRepository.save(it.copy(saksId = null))
+            assert(oppdatertSøknad.saksId == null)
+        }
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<SifInnsynApiApplication>(*args)

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
@@ -81,9 +81,8 @@ internal class JoarkKafkaConfig(
                 loggAntallForsøk(it)
 
                 val journalføringsHendelse = it.value()
-                val søknadEksisterer = søknadService.søknadGittJournalpostIdEksisterer("${journalføringsHendelse.journalpostId}")
                 when {
-                    journalføringsHendelse.erRelevant() && søknadEksisterer -> {
+                    journalføringsHendelse.erRelevant() && søknadEksisterer(journalføringsHendelse) -> {
                         MDCUtil.toMDC(Constants.JOURNALPOST_ID, journalføringsHendelse.journalpostId)
                         false
                     }
@@ -91,6 +90,9 @@ internal class JoarkKafkaConfig(
                 }
             }
         }
+
+    private fun søknadEksisterer(journalføringsHendelse: JournalfoeringHendelseRecord) =
+        søknadService.søknadGittJournalpostIdEksisterer("${journalføringsHendelse.journalpostId}")
 
     private fun loggAntallForsøk(it: ConsumerRecord<Long, JournalfoeringHendelseRecord>) {
         val antallForsøk = ByteBuffer.wrap(

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
@@ -40,7 +40,7 @@ internal class JoarkKafkaConfig(
             mutableMapOf<String, Any>(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to consumerProps.enableAutoCommit,
                 ConsumerConfig.GROUP_ID_CONFIG to consumerProps.groupId,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest", // TODO: 11/11/2021 Sett til consumerProps.autoOffsetReset etter prodsetting.
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to consumerProps.autoOffsetReset,
                 ConsumerConfig.ISOLATION_LEVEL_CONFIG to consumerProps.isolationLevel,
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to consumerProps.keyDeserializer,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to "io.confluent.kafka.serializers.KafkaAvroDeserializer",

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
@@ -40,7 +40,7 @@ internal class JoarkKafkaConfig(
             mutableMapOf<String, Any>(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to consumerProps.enableAutoCommit,
                 ConsumerConfig.GROUP_ID_CONFIG to consumerProps.groupId,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to consumerProps.autoOffsetReset,
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest", // TODO: 11/11/2021 Sett til consumerProps.autoOffsetReset etter prodsetting.
                 ConsumerConfig.ISOLATION_LEVEL_CONFIG to consumerProps.isolationLevel,
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to consumerProps.keyDeserializer,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to "io.confluent.kafka.serializers.KafkaAvroDeserializer",

--- a/src/main/kotlin/no/nav/sifinnsynapi/konsument/dokumentjournalforing/JoarkHendelseKonsument.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsument/dokumentjournalforing/JoarkHendelseKonsument.kt
@@ -22,6 +22,7 @@ class JoarkHendelseKonsument(
 
     companion object {
         private val logger = LoggerFactory.getLogger(JoarkHendelseKonsument::class.java)
+        private val K9_FAGSAK_SYSTEM = "K9"
     }
 
     @KafkaListener(
@@ -42,27 +43,30 @@ class JoarkHendelseKonsument(
         runBlocking {
             logger.info("Slår opp journalpostinfo...")
             val journalpostinfo = safService.hentJournalpostinfo(journalpostId)
-            when (val fagsakId = journalpostinfo.sak?.fagsakId) {
-                null -> {
-                    logger.info("Sak eller fagsakId var null. Ignorerer melding.")
-                } // ikke gjør noe
+            logger.info("JournalpostInfo hentet.")
 
-                else -> {
-                    MDCUtil.toMDC(Constants.K9_SAK_ID, fagsakId)
-                    logger.info("JournalpostInfo hentet.")
+            val fagsak = journalpostinfo.sak
 
+            when {
+                (fagsak != null) && (fagsak.fagsaksystem == K9_FAGSAK_SYSTEM) && !fagsak.fagsakId.isNullOrBlank() -> {
+
+                    MDCUtil.toMDC(Constants.K9_SAK_ID, fagsak.fagsakId)
                     logger.info("Oppdaterer søknad med saksId...")
                     try {
-                        val oppdatertSøknad = søknadService.oppdaterSøknadSaksIdGittJournalpostId(fagsakId, journalpostId)
+                        val oppdatertSøknad =
+                            søknadService.oppdaterSøknadSaksIdGittJournalpostId(fagsak.fagsakId, journalpostId)
                         logger.info("Søknad oppdatert med saksId: {}", oppdatertSøknad)
                     } catch (ex: Throwable) {
-                        when(ex) {
+                        when (ex) {
                             is SøknadWithJournalpostIdNotFoundException -> {
                                 logger.info("${ex.message} Ignorerer.")
                             }
                             else -> throw ex
                         }
                     }
+                }
+                else -> {
+                    logger.info("Sak eller fagsakId var null. Ignorerer melding.")
                 }
             }
         }

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
@@ -12,6 +12,7 @@ interface SøknadRepository : JpaRepository<SøknadDAO, UUID> {
     fun findAllByAktørId(aktørId: AktørId): List<SøknadDAO>
     fun findByJournalpostId(journalpostId: String): SøknadDAO?
     fun existsSøknadDAOByAktørIdAndJournalpostId(aktørId: AktørId, journalpostId: String): Boolean
+    fun findAllBySaksIdIsNotNull(): List<SøknadDAO> // TODO: 11/11/2021 Kan fjernes etter prodsetting
 
     @Query(
             value = "SELECT COUNT(DISTINCT aktør_id) FROM søknad",

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -69,5 +69,5 @@ topic:
     dok-journalfoering-v1:
       id: dok-journalfoering-v1-listener
       navn: aapen-dok-journalfoering-v1-q1
-      bryter: false
+      bryter: true
       dry-run: false

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -69,5 +69,5 @@ topic:
     dok-journalfoering-v1:
       id: dok-journalfoering-v1-listener
       navn: aapen-dok-journalfoering-v1-q1
-      bryter: true
+      bryter: false
       dry-run: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ topic:
     dok-journalfoering-v1:
       id: dok-journalfoering-v1-listener
       navn: aapen-dok-journalfoering-v1-p
-      bryter: true
+      bryter: false
       dry-run: false
 
 management:

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsument/OnpremKafkaHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsument/OnpremKafkaHendelseKonsumentIntegrasjonsTest.kt
@@ -266,6 +266,7 @@ class OnpremKafkaHendelseKonsumentIntegrasjonsTest {
     }
 
     @Test
+    @Disabled("Skru på igjen etter prodsetting") // TODO: 11/11/2021 Skrus på igjen etter prodsetting.
     fun `gitt eksisterende søknad, konsumer fra joark, slå opp journalpostinfo og oppdater søknad med saksId`() {
         val journalpostId: Long = 987654321
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
@@ -59,6 +59,9 @@ class SøknadControllerTest {
     @MockkBean
     lateinit var dokumentService: DokumentService
 
+    @MockkBean(relaxed = true) // TODO: 11/11/2021 Kan fjernes etter prodsetting
+    lateinit var søknadRepository: SøknadRepository
+
     @BeforeAll
     internal fun setUp() {
         assertNotNull(mockOAuth2Server)


### PR DESCRIPTION
Da det ikke var satt filtrering på fagsaksystem, har mange sakId-er blitt overskrevet fra andre fagsaksystemer enn k9.
Denne fiksen henter alle søknader med sakId-er og resetter dem.
Konsumering fra joark skrus av og setter `kafka_auto_offset_reset` til `earliest` for å konsumere dem på nytt etter at konsumering skrus på.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>