### PR TITLE
Bruker loginservice token framfor tokenX for kall mot k9-sak-innsyn-api.

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynApiService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynApiService.kt
@@ -4,7 +4,6 @@ import no.nav.k9.søknad.Søknad
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpMethod
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Recover
@@ -15,7 +14,6 @@ import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
-import java.util.*
 
 @Service
 @Retryable(
@@ -40,12 +38,12 @@ class K9SakInnsynApiService(
             .toUriString()
     }
 
-    fun hentSøknadsopplysninger(): K9SakInnsynSøknad {
+    fun hentSøknadsopplysninger(): K9SakInnsynSøknader {
         val exchange = k9SakInnsynClient.exchange(
             søknaddataUrl,
             HttpMethod.GET,
             null,
-            K9SakInnsynSøknad::class.java)
+            K9SakInnsynSøknader::class.java)
         logger.info("Fikk response {} for oppslag av søknadsdata fra k9-sak-innsyn-api", exchange.statusCode)
 
         return if (exchange.statusCode.is2xxSuccessful) {
@@ -57,24 +55,24 @@ class K9SakInnsynApiService(
     }
 
     @Recover
-    private fun recover(error: HttpServerErrorException): K9SakInnsynSøknad {
+    private fun recover(error: HttpServerErrorException): K9SakInnsynSøknader {
         logger.error("Error response = '${error.responseBodyAsString}' fra '${søknaddataUrl}'")
         throw IllegalStateException("Feilet med henting av k9 søknadsdata.")
     }
 
     @Recover
-    private fun recover(error: HttpClientErrorException): K9SakInnsynSøknad {
+    private fun recover(error: HttpClientErrorException): K9SakInnsynSøknader {
         logger.error("Error response = '${error.responseBodyAsString}' fra '${søknaddataUrl}'")
         throw IllegalStateException("Feilet med henting av k9 søknadsdata.")
     }
 
     @Recover
-    private fun recover(error: ResourceAccessException): K9SakInnsynSøknad {
+    private fun recover(error: ResourceAccessException): K9SakInnsynSøknader {
         logger.error("{}", error.message)
         throw IllegalStateException("Timout ved henting av k9 søknadsdata.")
     }
 }
 
-data class K9SakInnsynSøknad(
+data class K9SakInnsynSøknader(
     val søknad: Søknad
 )

--- a/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynSøknadController.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynSøknadController.kt
@@ -20,7 +20,7 @@ class K9SakInnsynSøknadController(
     @GetMapping(K9_SAK_INNSYN, produces = [MediaType.APPLICATION_JSON_VALUE])
     @Protected
     @ResponseStatus(OK)
-    fun hentSøknader(): K9SakInnsynSøknad {
+    fun hentSøknader(): K9SakInnsynSøknader {
         logger.info("Henter innsyn i søknadsopplysninger...")
         val søknader = k9SakInnsynApiService.hentSøknadsopplysninger()
         return søknader

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -52,17 +52,6 @@ no.nav.security.jwt:
         token-exchange:
           audience: ${SAFSELVBETJENING_TOKEN_X_AUDIENCE}
 
-      tokenx-k9-sak-innsyn-api:
-        token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-auth-method: private_key_jwt
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-        token-exchange:
-          audience: ${K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE}
-
-
 topic:
   listener:
     # topic.listener.dok-journalfoering-v1

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -66,16 +66,6 @@ no.nav:
           token-exchange:
               audience: ${SAFSELVBETJENING_TOKEN_X_AUDIENCE}
 
-        tokenx-k9-sak-innsyn-api:
-          token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-          grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-          authentication:
-            client-auth-method: private_key_jwt
-            client-id: ${TOKEN_X_CLIENT_ID}
-            client-jwk: ${TOKEN_X_PRIVATE_JWK}
-          token-exchange:
-            audience: ${K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE}
-
   dittnav:
     pleiepenger-sykt-barn:
       beskjed:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,16 +27,6 @@ no.nav:
               client-jwk: src/test/resources/tokenx-jwk.json
             token-exchange:
               audience: dev-fss:teamdokumenthandtering:safselvbetjening
-
-          tokenx-k9-sak-innsyn-api:
-            token-endpoint-url: http://localhost:8080/default/token
-            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-            authentication:
-              client-auth-method: private_key_jwt
-              client-id: "dev-gcp:dusseldorf:sif-innsyn-api"
-              client-jwk: src/test/resources/tokenx-jwk.json
-            token-exchange:
-              audience: dev-gcp:dusseldorf:k9-sak-innsyn-api
     cors:
       allowed-origins: http://localhost:8080
 


### PR DESCRIPTION
Pga. av at k9-sak-innsyn-api også kaller k9-selvbetjening-oppslag for å hente aktørId for søker og barn, er man nødt til å bruke token fra loginservice, fram til tokenX er støttet på k9-selvbetjening.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>