### PR TITLE
Overstyrer log4j versjon med sårbarhet.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ val k9FormatVersion by extra("5.5.20")
 
 ext["okhttp3.version"] = okHttp3Version
 ext["testcontainersVersion"] = "1.15.3"
+ext["log4j2.version"] = "2.15.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Info om sårbarhet: https://nvd.nist.gov/vuln/detail/CVE-2021-44228
Info fra Spring Boot: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>