### PR TITLE
Setter auto.offset.reset til none (se prod-gcp.json).

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ val teamDokumenthåndteringAvroSchemaVersion by extra("bbea40a3")
 
 ext["okhttp3.version"] = okHttp3Version
 ext["testcontainersVersion"] = "1.15.3"
-ext["log4j2.version"] = "2.15.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
+ext["log4j2.version"] = "2.16.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
@@ -40,7 +40,7 @@ internal class JoarkKafkaConfig(
             mutableMapOf<String, Any>(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to consumerProps.enableAutoCommit,
                 ConsumerConfig.GROUP_ID_CONFIG to consumerProps.groupId,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "latest", // TODO: 14/12/2021 Settes tilbake til consumerProps.autoOffsetReset når consumer har offset.
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to consumerProps.autoOffsetReset,
                 ConsumerConfig.ISOLATION_LEVEL_CONFIG to consumerProps.isolationLevel,
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to consumerProps.keyDeserializer,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to "io.confluent.kafka.serializers.KafkaAvroDeserializer",


### PR DESCRIPTION
Oppdaterer log4j2 til 2.16.0.

Håndterer potensiell DoS angrep. 
Se her for mer info: https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/#notes-on-the-denial-of-service-in-2150

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>