### PR TITLE
Oppdaterer spring boot, plugins, pakker og actions.

### DIFF
--- a/.github/workflows/apply-alerts.yml
+++ b/.github/workflows/apply-alerts.yml
@@ -17,7 +17,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/dev-') || startsWith(github.ref, 'refs/heads/master') # Deploy if branch is either master or dev-*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -30,7 +30,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master')  # If the branch is master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,19 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: actions/checkout@v2.4.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Test Code
         run: ./gradlew check
 
@@ -46,19 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: actions/checkout@v2.4.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Build JAR
         run: ./gradlew clean build -x test # Creates a combined JAR of project and runTime dependencies.
       - name: Build and publish Docker image
@@ -73,7 +61,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -87,7 +75,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,5 +1,8 @@
 name: Vulnerabilities scanning of dependencies
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron:  '0 3 * * *'
 
@@ -7,7 +10,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle-jdk11@master
@@ -17,4 +20,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           command: monitor
-          args: --org=dusseldorf --configuration-attributes=usage:java-runtime --project-name=${{ github.repository }} --remote-repo-url=https://github.com/${{ github.repository }}.git
+          args: --org=dusseldorf --configuration-matching=^runtimeClasspath$|^compileClasspath$ --project-name=${{ github.repository }} --remote-repo-url=https://github.com/${{ github.repository }}.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.5.5"
+    id("org.springframework.boot") version "2.5.8"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    id("com.expediagroup.graphql") version "4.2.0"
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.spring") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    id("com.expediagroup.graphql") version "5.3.1"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.spring") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
 }
 
 group = "no.nav"
@@ -28,7 +28,7 @@ val springCloudVersion by extra("2020.0.3")
 val retryVersion by extra("1.3.0")
 val zalandoVersion by extra("0.26.2")
 val openhtmltopdfVersion = "1.0.10"
-val handlebarsVersion = "4.2.0"
+val handlebarsVersion = "4.3.0"
 val hibernateTypes52Version by extra("2.11.1")
 val awailitilityKotlinVersion by extra("4.1.0")
 val assertkJvmVersion by extra("0.24")
@@ -37,13 +37,12 @@ val mockkVersion by extra("1.11.0")
 val guavaVersion by extra("23.0")
 val okHttp3Version by extra("4.9.1")
 val orgJsonVersion by extra("20210307")
-val graphQLKotlinVersion by extra("4.2.0")
+val graphQLKotlinVersion by extra("5.3.1")
 val k9FormatVersion by extra("5.5.20")
 val teamDokumenthåndteringAvroSchemaVersion by extra("bbea40a3")
 
 ext["okhttp3.version"] = okHttp3Version
 ext["testcontainersVersion"] = "1.15.3"
-ext["log4j2.version"] = "2.16.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 repositories {
     mavenCentral()
@@ -181,16 +180,16 @@ tasks.getByName<Jar>("jar") {
  * For å generere flere, må først den default "task"en hentes og konfigureres, og deretter opprette en ny "task" for en ny endepunkt.
  *
  * For mer info, se lenke under
- * https://opensource.expediagroup.com/graphql-kotlin/docs/4.x.x/plugins/gradle-plugin-usage#generating-multiple-clients
+ * https://opensource.expediagroup.com/graphql-kotlin/docs/plugins/gradle-plugin-usage#generating-multiple-clients
  */
 val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
-    queryFileDirectory.set("${project.projectDir}/src/main/resources/saf")
+    queryFileDirectory.set(file("${project.projectDir}/src/main/resources/saf"))
     schemaFile.set(file("${project.projectDir}/src/main/resources/saf/saf-api-sdl.graphqls"))
     packageName.set("no.nav.sifinnsynapi.saf.generated")
 }
 
 val graphqlGenerateOtherClient by tasks.creating(GraphQLGenerateClientTask::class) {
-    queryFileDirectory.set("${project.projectDir}/src/main/resources/safselvbetjening")
+    queryFileDirectory.set(file("${project.projectDir}/src/main/resources/safselvbetjening"))
     schemaFile.set(file("${project.projectDir}/src/main/resources/safselvbetjening/saf-selvbetjening-sdl.graphqls"))
     packageName.set("no.nav.sifinnsynapi.safselvbetjening.generated")
 }


### PR DESCRIPTION
- Analyserer kun runtimeClasspath og compileClasspath med snyk.
- Erstatter gh actions cache med cache fra setup-java.
- Fjerner overstyring av log4j2.version da siste versjon er på 2.17.0 med spring boot 2.5.8.
- Closes #190
- Closes #189
- Closes #185
- Closes #179
- Closes #177
- Closes #166
- Closes #157

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>