### PR TITLE
Oppgraderer Spring Boot, pakker, og actions.

### DIFF
--- a/.github/workflows/apply-alerts.yml
+++ b/.github/workflows/apply-alerts.yml
@@ -17,7 +17,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/dev-') || startsWith(github.ref, 'refs/heads/master') # Deploy if branch is either master or dev-*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -30,7 +30,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master')  # If the branch is master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'zulu'
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'zulu'
@@ -61,7 +61,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -75,7 +75,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle-jdk11@master

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Applikasjonen er konfigurert med en lokal oicd provider stub for å utsending og
 #### Henting av token
 1. Åpne oicd-provider-gui i nettleseren enten ved å bruke docker dashbord, eller ved å gå til http://localhost:5000.
 2. Trykk "Token for nivå 4" for å logge inn med ønsket bruker, ved å oppgi fødselsnummer. Tokenet blir da satt som en cookie (selvbetjening-idtoken) i nettleseren.
-3. Deretter kan du åpne http://localhost:8080/swagger-ui/index.html for å teste ut endepunktene.
+3. Deretter kan du åpne http://localhost:8080/swagger-ui.html for å teste ut endepunktene.
 
 Om man ønsker å bruke postman må man selv, lage en cookie og sette tokenet manuelt. Eksempel:
 selvbetjening-idtoken=eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp.eyJzdWIiOiIwMTAxMDExMjM0NSIsImFjc.FBmVFuHI9d8akrVdAxi1dRg03qKV4EGk; Path=/; Domain=localhost; Expires=Fri, 18 Jun 2021 08:46:13 GMT;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ val orgJsonVersion by extra("20210307")
 val graphQLKotlinVersion by extra("5.3.2")
 val k9FormatVersion by extra("5.5.20")
 val teamDokumenthåndteringAvroSchemaVersion by extra("bbea40a3")
+val springdocVersion by extra("1.6.6")
 
 ext["okhttp3.version"] = okHttp3Version
 ext["testcontainersVersion"] = "1.16.3"
@@ -60,7 +61,6 @@ repositories {
         }
     }
 }
-
 dependencies {
 
     // NAV
@@ -98,10 +98,9 @@ dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-stub-runner")
     testImplementation("org.springframework.cloud:spring-cloud-starter")
 
-    // SpringFox
-    /*implementation("io.springfox:springfox-boot-starter:$springfoxVersion")*/
-    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
+    // Swagger (openapi 3)
+    implementation("org.springdoc:springdoc-openapi-kotlin:$springdocVersion")
+    implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")
 
 
     // Metrics

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 
     // SpringFox
     /*implementation("io.springfox:springfox-boot-starter:$springfoxVersion")*/
-    //implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
+    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
     implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ configurations {
 
 val confluentVersion by extra("5.5.0")
 val logstashLogbackEncoderVersion by extra("6.6")
-val tokenSupportVersion by extra("1.3.8")
+val tokenSupportVersion by extra("1.3.19")
 val springCloudVersion by extra("2021.0.1")
 val retryVersion by extra("1.3.0")
 val zalandoVersion by extra("0.26.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 
     // SpringFox
     /*implementation("io.springfox:springfox-boot-starter:$springfoxVersion")*/
-    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
+    //implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
     implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.5.8"
+    id("org.springframework.boot") version "2.6.5"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("com.expediagroup.graphql") version "5.3.1"
     kotlin("jvm") version "1.6.10"
@@ -20,11 +20,10 @@ configurations {
     }
 }
 
-val springfoxVersion by extra("3.0.0")
 val confluentVersion by extra("5.5.0")
 val logstashLogbackEncoderVersion by extra("6.6")
 val tokenSupportVersion by extra("1.3.8")
-val springCloudVersion by extra("2020.0.3")
+val springCloudVersion by extra("2021.0.1")
 val retryVersion by extra("1.3.0")
 val zalandoVersion by extra("0.26.2")
 val openhtmltopdfVersion = "1.0.10"
@@ -42,7 +41,7 @@ val k9FormatVersion by extra("5.5.20")
 val teamDokumenthåndteringAvroSchemaVersion by extra("bbea40a3")
 
 ext["okhttp3.version"] = okHttp3Version
-ext["testcontainersVersion"] = "1.15.3"
+ext["testcontainersVersion"] = "1.16.3"
 
 repositories {
     mavenCentral()
@@ -100,7 +99,10 @@ dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter")
 
     // SpringFox
-    implementation("io.springfox:springfox-boot-starter:$springfoxVersion")
+    /*implementation("io.springfox:springfox-boot-starter:$springfoxVersion")*/
+    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.6")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
+
 
     // Metrics
     implementation("io.micrometer:micrometer-registry-prometheus")
@@ -113,8 +115,8 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     runtimeOnly("org.hibernate:hibernate-jpamodelgen")
     implementation("com.vladmihalcea:hibernate-types-52:$hibernateTypes52Version")
-    testImplementation("org.testcontainers:junit-jupiter")
-    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:junit-jupiter:1.16.3")
+    testImplementation("org.testcontainers:postgresql:1.16.3")
 
     // Jackson
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.6.5"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    id("com.expediagroup.graphql") version "5.3.1"
+    id("com.expediagroup.graphql") version "5.3.2"
     kotlin("jvm") version "1.6.10"
     kotlin("plugin.spring") version "1.6.10"
     kotlin("plugin.jpa") version "1.6.10"
@@ -36,7 +36,7 @@ val mockkVersion by extra("1.11.0")
 val guavaVersion by extra("23.0")
 val okHttp3Version by extra("4.9.1")
 val orgJsonVersion by extra("20210307")
-val graphQLKotlinVersion by extra("5.3.1")
+val graphQLKotlinVersion by extra("5.3.2")
 val k9FormatVersion by extra("5.5.20")
 val teamDokumenthåndteringAvroSchemaVersion by extra("bbea40a3")
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
@@ -3,6 +3,6 @@ package no.nav.sifinnsynapi.config
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.springframework.context.annotation.Configuration
 
-@EnableJwtTokenValidation(ignore = ["org.springframework", "springfox.documentation"])
+@EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @Configuration
 internal class SecurityConfiguration

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Profile
 
 @Configuration
 @Profile("local", "dev-gcp")
-@Unprotected
 class SwaggerConfiguration {
 
     @Bean

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -1,8 +1,12 @@
 package no.nav.sifinnsynapi.config
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
 import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,12 +16,22 @@ import org.springframework.core.env.Environment
 
 @Configuration
 @Profile("local", "dev-gcp")
+@SecurityScheme(
+    name = "cookieAuth",
+    type = SecuritySchemeType.APIKEY,
+    `in` = SecuritySchemeIn.COOKIE,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
 class SwaggerConfiguration : EnvironmentAware {
     private var env: Environment? = null
 
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
+            .security(listOf(
+                SecurityRequirement().addList("")
+            ))
             .info(
                 Info()
                     .title("Sif Innsyn Api")

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -17,20 +17,13 @@ import org.springframework.core.env.Environment
 
 @Configuration
 @Profile("local", "dev-gcp")
-@SecurityScheme(
-    name = "cookieAuth",
-    type = SecuritySchemeType.APIKEY,
-    `in` = SecuritySchemeIn.COOKIE,
-    scheme = "bearer",
-    bearerFormat = "JWT"
-)
 class SwaggerConfiguration : EnvironmentAware {
     private var env: Environment? = null
 
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
-            .addServersItem(Server().url("https://sif-innsyn-api.dev.nav.no").description("Swagger Server"))
+            .addServersItem(Server().url("https://sif-innsyn-api.dev.nav.no/").description("Swagger Server"))
             .security(listOf(
                 SecurityRequirement().addList("")
             ))

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -24,9 +24,6 @@ class SwaggerConfiguration : EnvironmentAware {
     fun openAPI(): OpenAPI {
         return OpenAPI()
             .addServersItem(Server().url("https://sif-innsyn-api.dev.nav.no/").description("Swagger Server"))
-            .security(listOf(
-                SecurityRequirement().addList("")
-            ))
             .info(
                 Info()
                     .title("Sif Innsyn Api")

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -1,29 +1,23 @@
 package no.nav.sifinnsynapi.config
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
-import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.servers.Server
-import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.core.env.Environment
-
 
 @Configuration
 @Profile("local", "dev-gcp")
-class SwaggerConfiguration : EnvironmentAware {
-    private var env: Environment? = null
+class SwaggerConfiguration {
 
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
-            .addServersItem(Server().url("https://sif-innsyn-api.dev.nav.no/").description("Swagger Server"))
+            .addServersItem(
+                Server().url("https://sif-innsyn-api.dev.nav.no/").description("Swagger Server")
+            )
             .info(
                 Info()
                     .title("Sif Innsyn Api")
@@ -35,9 +29,5 @@ class SwaggerConfiguration : EnvironmentAware {
                     .description("sif-innsyn-api github repository")
                     .url("https://github.com/navikt/sif-innsyn-api")
             )
-    }
-
-    override fun setEnvironment(env: Environment) {
-        this.env = env
     }
 }

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.servers.Server
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -27,7 +26,7 @@ class SwaggerConfiguration {
             )
             .externalDocs(
                 ExternalDocumentation()
-                    .description("sif-innsyn-api github repository")
+                    .description("Sif Innsyn Api GitHub repository")
                     .url("https://github.com/navikt/sif-innsyn-api")
             )
     }

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.servers.Server
+import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 
 @Configuration
 @Profile("local", "dev-gcp")
+@Unprotected
 class SwaggerConfiguration {
 
     @Bean

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,6 +30,7 @@ class SwaggerConfiguration : EnvironmentAware {
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
+            .addServersItem(Server().url("https://sif-innsyn-api.dev.nav.no").description("Swagger Server"))
             .security(listOf(
                 SecurityRequirement().addList("")
             ))

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -1,14 +1,14 @@
 package no.nav.sifinnsynapi.config
 
-import io.swagger.models.Scheme
+import io.swagger.v3.oas.models.ExternalDocumentation
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
 import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.core.env.Environment
-import springfox.documentation.builders.RequestHandlerSelectors
-import springfox.documentation.spi.DocumentationType
-import springfox.documentation.spring.web.plugins.Docket
+
 
 @Configuration
 @Profile("local", "dev-gcp")
@@ -16,12 +16,19 @@ class SwaggerConfiguration : EnvironmentAware {
     private var env: Environment? = null
 
     @Bean
-    fun api(): Docket {
-        return Docket(DocumentationType.SWAGGER_2)
-                .protocols(setOf(Scheme.HTTPS.toValue(), Scheme.HTTP.toValue()))
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("no.nav.sifinnsynapi"))
-                .build()
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Sif Innsyn Api")
+                    .description("API spesifikasjon for sif-innsyn-api")
+                    .version("v1.0.0")
+            )
+            .externalDocs(
+                ExternalDocumentation()
+                    .description("sif-innsyn-api github repository")
+                    .url("https://github.com/navikt/sif-innsyn-api")
+            )
     }
 
     override fun setEnvironment(env: Environment) {

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/WebMvcConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/WebMvcConfig.kt
@@ -41,22 +41,6 @@ class WebMvcConfig(
         super.addCorsMappings(registry)
     }
 
-    /**
-     * Add handlers to serve static resources such as images, js, and, css
-     * files from specific locations under web application root, the classpath,
-     * and others.
-     */
-    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
-
-        registry.addResourceHandler("swagger-ui.html")
-            .addResourceLocations("classpath:/META-INF/resources/");
-
-        registry.addResourceHandler("/webjars/**")
-            .addResourceLocations("classpath:/META-INF/resources/webjars/");
-
-        super.addResourceHandlers(registry)
-    }
-
     @Bean
     fun problemModules(): ProblemModule {
         return ProblemModule()

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/CommonKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/CommonKafkaConfig.kt
@@ -16,6 +16,7 @@ import org.json.JSONObject
 import org.slf4j.Logger
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.*
+import org.springframework.kafka.listener.ConsumerRecordRecoverer
 import org.springframework.kafka.listener.ContainerProperties
 import org.springframework.kafka.listener.DefaultAfterRollbackProcessor
 import org.springframework.kafka.support.KafkaHeaders
@@ -151,7 +152,7 @@ class CommonKafkaConfig {
             factory.containerProperties.transactionManager = transactionManager
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#exactly-once
-            factory.containerProperties.eosMode = ContainerProperties.EOSMode.BETA
+            factory.containerProperties.eosMode = ContainerProperties.EOSMode.V2
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#committing-offsets
             factory.containerProperties.ackMode = ContainerProperties.AckMode.RECORD;
@@ -160,7 +161,7 @@ class CommonKafkaConfig {
             factory.containerProperties.isDeliveryAttemptHeader = true
 
             // https://docs.spring.io/spring-kafka/reference/html/#listener-container
-            factory.containerProperties.authorizationExceptionRetryInterval = Duration.ofSeconds(10L)
+            factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(10L))
 
             //https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#after-rollback
 
@@ -176,7 +177,7 @@ class CommonKafkaConfig {
             }
 
 
-        fun defaultRecoverer(logger: Logger) = BiConsumer { cr: ConsumerRecord<*, *>, ex: Exception ->
+        fun defaultRecoverer(logger: Logger) = ConsumerRecordRecoverer { cr: ConsumerRecord<*, *>, ex: Exception ->
             logger.error("Retry attempts exhausted for ${cr.topic()}-${cr.partition()}@${cr.offset()}", ex)
         }
     }

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/JoarkKafkaConfig.kt
@@ -15,7 +15,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
 import org.springframework.kafka.listener.ContainerProperties
-import org.springframework.kafka.listener.SeekToCurrentErrorHandler
+import org.springframework.kafka.listener.DefaultErrorHandler
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.util.backoff.FixedBackOff
 import java.nio.ByteBuffer
@@ -58,7 +58,7 @@ internal class JoarkKafkaConfig(
             consumerFactory = joarkConsumerFactory
 
             // https://docs.spring.io/spring-kafka/reference/html/#listener-container
-            containerProperties.authorizationExceptionRetryInterval = Duration.ofSeconds(10L)
+            containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(10L))
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#delivery-header
             containerProperties.isDeliveryAttemptHeader = true
@@ -67,11 +67,11 @@ internal class JoarkKafkaConfig(
             containerProperties.ackMode = ContainerProperties.AckMode.RECORD;
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#exactly-once
-            containerProperties.eosMode = ContainerProperties.EOSMode.BETA
+            containerProperties.eosMode = ContainerProperties.EOSMode.V2
 
             // https://docs.spring.io/spring-kafka/reference/html/#seek-to-current
-            setErrorHandler(
-                SeekToCurrentErrorHandler(
+            setCommonErrorHandler(
+                DefaultErrorHandler(
                     defaultRecoverer(logger),
                     FixedBackOff(kafkaClusterProperties.aiven.consumer.retryInterval, Long.MAX_VALUE)
                 )

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -1,5 +1,8 @@
 management:
   endpoint:
+    web:
+      exposure:
+        include: *
     health:
       show-details: always
 

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -2,7 +2,7 @@ management:
   endpoint:
     web:
       exposure:
-        include: *
+        include: '*'
     health:
       show-details: always
 

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -71,3 +71,7 @@ no.nav:
 
   metrics:
     interval: 3_600_000 # 1 time
+
+springdoc:
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,6 +138,5 @@ kafka:
       retries: 3
 
 springdoc:
-  packagesToScan: no.nav.sifinnsynapi
   swagger-ui:
     disable-swagger-default-url: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,8 +139,3 @@ kafka:
 
 springdoc:
   version: 1.0
-  api-docs:
-    path: /api-docs
-  swagger-ui:
-    use-root-path: true
-    path: /swagger

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,3 +139,5 @@ kafka:
 
 springdoc:
   version: '1.0.0'
+  swagger-ui:
+    use-root-path: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,3 +137,5 @@ kafka:
       transaction-id-prefix: .tx-
       retries: 3
 
+springdoc:
+  packagesToScan: no.nav.sifinnsynapi

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -136,3 +136,13 @@ kafka:
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
       transaction-id-prefix: .tx-
       retries: 3
+
+springdoc:
+  show-actuator: false
+  version: '1.0.0'
+  swagger-ui:
+    display-request-duration: true
+    groups-order: DESC
+    operationsSorter: method
+    disable-swagger-default-url: true
+    use-root-path: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,3 +139,5 @@ kafka:
 
 springdoc:
   packagesToScan: no.nav.sifinnsynapi
+  swagger-ui:
+    disable-swagger-default-url: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,3 +140,4 @@ kafka:
 springdoc:
   swagger-ui:
     disable-swagger-default-url: true
+    path: swagger-ui.html

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,5 +137,3 @@ kafka:
       transaction-id-prefix: .tx-
       retries: 3
 
-springdoc:
-  version: 1.0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,6 +138,9 @@ kafka:
       retries: 3
 
 springdoc:
-  version: '1.0.0'
+  version: 1.0
+  api-docs:
+    path: /api-docs
   swagger-ui:
     use-root-path: true
+    path: /swagger

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,11 +138,4 @@ kafka:
       retries: 3
 
 springdoc:
-  show-actuator: false
   version: '1.0.0'
-  swagger-ui:
-    display-request-duration: true
-    groups-order: DESC
-    operationsSorter: method
-    disable-swagger-default-url: true
-    use-root-path: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,13 +37,13 @@ application-ingress: http://localhost:9999
 
 spring:
   datasource:
-    url: jdbc:tc:postgresql:9.6:///
+    url: jdbc:tc:postgresql:12:///
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   flyway:
     enabled: true
   jpa:
     show-sql: true
-    database-platform: org.hibernate.dialect.PostgreSQL9Dialect
+    database-platform: org.hibernate.dialect.PostgreSQL12Dialect
 
 logging:
   level:


### PR DESCRIPTION
Erstatter Springfox med Springdoc da den ikke fungerte som den skal etter opppdatering av Spring. Springdoc er et mer vedlikeholdt prosjekt og mer kompatibelt med spring og openapi.

- Fjerner resourceHandler config for swagger, da den ikke lenger er nødvendig.
- Oppdaterer tokenSupportVersion
- Oppdaterer springCloudVersion
- Oppdaterer testcontainers og postgresql db i test.
- Erstatter utgått kafka config.
- closes #204 
- closes #201
- closes #200
- closes #195 
