### PR TITLE
Rydder opp i application properties.

### DIFF
--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -41,7 +41,8 @@
     "TOKENDINGS_BASE_URL": "https://tokendings.dev-gcp.nais.io",
     "SAFSELVBETJENING_TOKEN_X_AUDIENCE": "dev-fss:teamdokumenthandtering:safselvbetjening-q1",
     "K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE": "dev-gcp:dusseldorf:k9-sak-innsyn-api",
-    "K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE": "dev-fss:dusseldorf:k9-selvbetjening-oppslag"
+    "K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE": "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
+    "SWAGGER_ENABLED": "true"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | sif-innsyn-api | "

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -16,9 +16,6 @@ spring:
 
 kafka:
   aiven:
-    consumer:
-      schemaRegistryUser: ${KAFKA_SCHEMA_REGISTRY_USER}
-      schemaRegistryPassword: ${KAFKA_SCHEMA_REGISTRY_PASSWORD}
     properties:
       security:
         protocol: SSL
@@ -29,46 +26,6 @@ kafka:
         key-store-location: file:${KAFKA_KEYSTORE_PATH}
         key-store-password: ${KAFKA_CREDSTORE_PASSWORD}
         key-store-type: PKCS12
-
-no.nav.security.jwt:
-  issuer:
-    loginservice:
-      discoveryUrl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL} # settes av configmap: loginservice-idporten i naiserator.yml
-      accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE} # settes av configmap: loginservice-idporten i naiserator.yml
-    tokenx:
-      discoveryUrl: ${TOKEN_X_WELL_KNOWN_URL}
-      accepted_audience: ${TOKEN_X_CLIENT_ID}
-  client:
-    registration:
-      tokenx-safselvbetjening:
-        token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-auth-method: private_key_jwt
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-        token-exchange:
-          audience: ${SAFSELVBETJENING_TOKEN_X_AUDIENCE}
-
-      tokenx-k9-sak-innsyn-api:
-        token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-auth-method: private_key_jwt
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-        token-exchange:
-          audience: ${K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE}
-
-      tokenx-k9-selvbetjening-oppslag:
-        token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-auth-method: private_key_jwt
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-        token-exchange:
-          audience: ${K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE}
 
 topic:
   listener:

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -19,9 +19,6 @@ management:
       show-details: never
 
 spring:
-  mvc:
-    log-request-details: false
-
   jpa:
     show-sql: false
     hibernate:
@@ -29,9 +26,6 @@ spring:
 
 kafka:
   aiven:
-    consumer:
-      schemaRegistryUser: ${KAFKA_SCHEMA_REGISTRY_USER}
-      schemaRegistryPassword: ${KAFKA_SCHEMA_REGISTRY_PASSWORD}
     properties:
       security:
         protocol: SSL
@@ -43,47 +37,6 @@ kafka:
         key-store-password: ${KAFKA_CREDSTORE_PASSWORD}
         key-store-type: PKCS12
 
-no.nav:
-  security.jwt:
-    issuer:
-      loginservice:
-        discoveryUrl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL} # settes av configmap: loginservice-idporten i naiserator.yml
-        accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE} # settes av configmap: loginservice-idporten i naiserator.yml
-      tokenx:
-        discoveryUrl: ${TOKEN_X_WELL_KNOWN_URL}
-        accepted_audience: ${TOKEN_X_CLIENT_ID}
-    client:
-      registration:
-        tokenx-safselvbetjening:
-          token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-          grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-          authentication:
-            client-auth-method: private_key_jwt
-            client-id: ${TOKEN_X_CLIENT_ID}
-            client-jwk: ${TOKEN_X_PRIVATE_JWK}
-          token-exchange:
-              audience: ${SAFSELVBETJENING_TOKEN_X_AUDIENCE}
-
-        tokenx-k9-sak-innsyn-api:
-          token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-          grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-          authentication:
-            client-auth-method: private_key_jwt
-            client-id: ${TOKEN_X_CLIENT_ID}
-            client-jwk: ${TOKEN_X_PRIVATE_JWK}
-          token-exchange:
-            audience: ${K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE}
-
-        tokenx-k9-selvbetjening-oppslag:
-          token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
-          grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-          authentication:
-            client-auth-method: private_key_jwt
-            client-id: ${TOKEN_X_CLIENT_ID}
-            client-jwk: ${TOKEN_X_PRIVATE_JWK}
-          token-exchange:
-            audience: ${K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE}
-
   dittnav:
     pleiepenger-sykt-barn:
       beskjed:
@@ -94,7 +47,3 @@ no.nav:
 
   metrics:
     interval: 3_600_000 # 1 time
-
-springdoc:
-  swagger-ui:
-    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,44 @@ no.nav:
     jwt:
       issuer:
         loginservice:
+          discoveryUrl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL} # settes av configmap: loginservice-idporten i naiserator.yml
+          accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE} # settes av configmap: loginservice-idporten i naiserator.yml
           cookie_name: # Settes inais/<cluster>.json
+        tokenx:
+          discoveryUrl: ${TOKEN_X_WELL_KNOWN_URL}
+          accepted_audience: ${TOKEN_X_CLIENT_ID}
+
+      client:
+        registration:
+          tokenx-safselvbetjening:
+            token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: ${TOKEN_X_CLIENT_ID}
+              client-jwk: ${TOKEN_X_PRIVATE_JWK}
+            token-exchange:
+              audience: ${SAFSELVBETJENING_TOKEN_X_AUDIENCE}
+
+          tokenx-k9-sak-innsyn-api:
+            token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: ${TOKEN_X_CLIENT_ID}
+              client-jwk: ${TOKEN_X_PRIVATE_JWK}
+            token-exchange:
+              audience: ${K9_SAK_INNSYN_API_TOKEN_X_AUDIENCE}
+
+          tokenx-k9-selvbetjening-oppslag:
+            token-endpoint-url: ${TOKENDINGS_BASE_URL}/token
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: ${TOKEN_X_CLIENT_ID}
+              client-jwk: ${TOKEN_X_PRIVATE_JWK}
+            token-exchange:
+              audience: ${K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE}
 
   metrics:
     interval: 60_000
@@ -120,6 +157,7 @@ spring:
 kafka:
   aiven:
     servers: ${KAFKA_BROKERS}
+
     consumer:
       enable-auto-commit: false
       group-id: ${spring.application.name}
@@ -129,6 +167,8 @@ kafka:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       schemaRegistryUrl: ${KAFKA_SCHEMA_REGISTRY}
+      schemaRegistryUser: ${KAFKA_SCHEMA_REGISTRY_USER}
+      schemaRegistryPassword: ${KAFKA_SCHEMA_REGISTRY_PASSWORD}
 
     producer:
       client-id: ${HOSTNAME}
@@ -138,6 +178,9 @@ kafka:
       retries: 3
 
 springdoc:
+  disable-swagger-default-url: true
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:false}
   swagger-ui:
-    disable-swagger-default-url: true
+    enabled: ${SWAGGER_ENABLED:false}
     path: swagger-ui.html

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -178,9 +178,9 @@ kafka:
       retries: 3
 
 springdoc:
-  disable-swagger-default-url: true
   api-docs:
     enabled: ${SWAGGER_ENABLED:false}
   swagger-ui:
     enabled: ${SWAGGER_ENABLED:false}
+    disable-swagger-default-url: true
     path: swagger-ui.html


### PR DESCRIPTION
- Flytter duplikat properties for no.nav.security.jwt til application.yml.
- Flytter springdoc properties til application.yml og toggler med miljøvariabel.
- Flytter duplikat schemaRegistryUser og schemaRegistryPassword til application.yml.
- Sletter spring.mvc.log-request-details fra application-prod-gcp.yml da den er false som default.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>