### PR TITLE
Fikser validering av claims for flere issuers.

### DIFF
--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -29,7 +29,6 @@
     "APPLICATION_INGRESS": "https://sif-innsyn-api.dev.nav.no",
     "SPRING_PROFILES_ACTIVE": "dev-gcp",
     "KAFKA_AIVEN_CONSUMER_AUTO_OFFSET_RESET": "latest",
-    "NO_NAV_SECURITY_JWT_ISSUER_LOGINSERVICE_COOKIE_NAME": "selvbetjening-idtoken",
     "NO_NAV_SECURITY_CORS_ALLOWED_ORIGINS": "https://sif-innsyn.dev.nav.no, https://endringsmelding-pleiepenger.dev.nav.no",
     "NO_NAV_GATEWAYS_K9_SELVBETJENING_OPPSLAG": "http://k9-selvbetjening-oppslag",
     "NO_NAV_GATEWAYS_SAF_BASE_URL": "https://saf.dev-fss-pub.nais.io",

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -29,7 +29,6 @@
     "APPLICATION_INGRESS": "https://sif-innsyn-api.nav.no",
     "SPRING_PROFILES_ACTIVE": "prod-gcp",
     "KAFKA_AIVEN_CONSUMER_AUTO_OFFSET_RESET": "none",
-    "NO_NAV_SECURITY_JWT_ISSUER_LOGINSERVICE_COOKIE_NAME": "selvbetjening-idtoken",
     "NO_NAV_SECURITY_CORS_ALLOWED_ORIGINS": "https://www.nav.no",
     "NO_NAV_GATEWAYS_K9_SELVBETJENING_OPPSLAG": "http://k9-selvbetjening-oppslag",
     "NO_NAV_GATEWAYS_SAF_BASE_URL": "https://saf.prod-fss-pub.nais.io",

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
@@ -6,3 +6,8 @@ import org.springframework.context.annotation.Configuration
 @EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @Configuration
 internal class SecurityConfiguration
+
+object Issuers {
+    const val ID_PORTEN = "idporten"
+    const val TOKEN_X = "tokenx"
+}

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadController.kt
@@ -1,8 +1,9 @@
 package no.nav.sifinnsynapi.soknad
 
-import no.nav.security.token.support.core.api.Protected
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.sifinnsynapi.Routes.SØKNAD
+import no.nav.sifinnsynapi.config.Issuers
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
@@ -14,7 +15,10 @@ import org.springframework.web.bind.annotation.*
 import java.util.*
 
 @RestController
-@ProtectedWithClaims(issuer = "selvbetjening", claimMap = ["acr=Level4"])
+@RequiredIssuers(
+    ProtectedWithClaims(issuer = Issuers.ID_PORTEN, claimMap = ["acr=Level4"]),
+    ProtectedWithClaims(issuer = Issuers.TOKEN_X, claimMap = ["acr=Level4"])
+)
 class SøknadController(
         private val søknadService: SøknadService
 ) {
@@ -23,7 +27,6 @@ class SøknadController(
     }
 
     @GetMapping(SØKNAD, produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Protected
     @ResponseStatus(OK)
     fun hentSøknader(): List<SøknadDTO> {
         logger.info("Forsøker å hente søknader...")
@@ -33,7 +36,6 @@ class SøknadController(
     }
 
     @GetMapping("$SØKNAD/{søknadId}", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Protected
     @ResponseStatus(OK)
     fun hentSøknad(@PathVariable søknadId: UUID): SøknadDTO {
         logger.info("Forsøker å hente søknad med id : {}...", søknadId)
@@ -41,7 +43,6 @@ class SøknadController(
     }
 
     @GetMapping("$SØKNAD/{søknadId}/arbeidsgivermelding", produces = [MediaType.APPLICATION_PDF_VALUE])
-    @Protected
     @ResponseStatus(OK)
     fun lastNedArbeidsgivermelding(
         @PathVariable søknadId: UUID,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ no.nav:
         idporten:
           discoveryUrl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL} # settes av configmap: loginservice-idporten i naiserator.yml
           accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE} # settes av configmap: loginservice-idporten i naiserator.yml
-          cookie_name: # Settes inais/<cluster>.json
+          cookie_name: selvbetjening-idtoken
         tokenx:
           discoveryUrl: ${TOKEN_X_WELL_KNOWN_URL}
           accepted_audience: ${TOKEN_X_CLIENT_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ no.nav:
       allowed-origins: # Settes i nais/<cluster>.json
     jwt:
       issuer:
-        loginservice:
+        idporten:
           discoveryUrl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL} # settes av configmap: loginservice-idporten i naiserator.yml
           accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE} # settes av configmap: loginservice-idporten i naiserator.yml
           cookie_name: # Settes inais/<cluster>.json

--- a/src/main/resources/bootstrap-local.yml
+++ b/src/main/resources/bootstrap-local.yml
@@ -1,7 +1,0 @@
-spring:
-   cloud:
-      gcp:
-         core:
-            enabled: false
-         secretmanager:
-            enabled: false

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsument/KafkaHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsument/KafkaHendelseKonsumentIntegrasjonsTest.kt
@@ -15,6 +15,7 @@ import no.nav.sifinnsynapi.common.AktørId
 import no.nav.sifinnsynapi.common.Fødselsnummer
 import no.nav.sifinnsynapi.common.SøknadsStatus
 import no.nav.sifinnsynapi.common.Søknadstype
+import no.nav.sifinnsynapi.config.Issuers
 import no.nav.sifinnsynapi.config.SecurityConfiguration
 import no.nav.sifinnsynapi.config.Topics.AAPEN_DOK_JOURNALFØRING_V1
 import no.nav.sifinnsynapi.config.Topics.K9_DITTNAV_VARSEL_BESKJED_AIVEN
@@ -459,7 +460,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
         JSONAssert.assertEquals(forventetResponse, body!!.somJson(mapper), JSONCompareMode.LENIENT)
     }
 
-    private fun hentToken(): HttpEntity<String> = mockOAuth2Server.hentToken(issuerId = "tokenx").tokenTilHttpEntity()
+    private fun hentToken(): HttpEntity<String> = mockOAuth2Server.hentToken(issuerId = Issuers.TOKEN_X).tokenTilHttpEntity()
 
     private fun stubDokumentOversikt() {
         coEvery {

--- a/src/test/kotlin/no/nav/sifinnsynapi/utils/TokenUtils.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/utils/TokenUtils.kt
@@ -2,13 +2,14 @@ package no.nav.sifinnsynapi.utils
 
 import com.nimbusds.jwt.SignedJWT
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.sifinnsynapi.config.Issuers
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 
 fun MockOAuth2Server.hentToken(
     subject: String = "12345678910",
-    issuerId: String = "loginservice",
-    claims: Map<String, String> = mapOf("acr" to "level4"),
+    issuerId: String = Issuers.ID_PORTEN,
+    claims: Map<String, String> = mapOf("acr" to "Level4"),
     audience: String = "aud-localhost",
     expiry: Long = 3600
 ): SignedJWT = issueToken(issuerId = issuerId, subject = subject, claims = claims, audience = audience, expiry = expiry)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,8 +12,8 @@ no.nav:
   security:
     jwt:
       issuer:
-        loginservice:
-          discoveryurl: http://localhost:${mock-oauth2-server.port}/loginservice/.well-known/openid-configuration
+        idporten:
+          discoveryurl: http://localhost:${mock-oauth2-server.port}/idporten/.well-known/openid-configuration
           accepted_audience: aud-localhost
           cookie_name: selvbetjening-idtoken
         tokenx:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,7 +15,6 @@ no.nav:
         idporten:
           discoveryurl: http://localhost:${mock-oauth2-server.port}/idporten/.well-known/openid-configuration
           accepted_audience: aud-localhost
-          cookie_name: selvbetjening-idtoken
         tokenx:
           discoveryurl: http://localhost:${mock-oauth2-server.port}/tokenx/.well-known/openid-configuration
           accepted_audience: aud-localhost


### PR DESCRIPTION
Håndhever sikkerhetsnivå 4 (acr=Level4).

- Oppretter konstanter for konfigurerte issuers.
- Sletter ubrukt bootstrap-local.yml.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>