### PR TITLE
Oppdaterer pakker og plugins (WIP)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,11 @@ plugins {
 
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_21
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 configurations {
     compileOnly {
@@ -107,6 +111,7 @@ dependencies {
     // Database
     runtimeOnly("org.postgresql:postgresql:$postgresqlVersion")
     implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
     testImplementation("org.testcontainers:junit-jupiter:$testContainersVersion")
     testImplementation("org.testcontainers:postgresql:$testContainersVersion")
 
@@ -159,9 +164,8 @@ tasks.withType<Test> {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "21"
+    compilerOptions {
+        freeCompilerArgs.add("-Xjsr305=strict")
     }
 }
 
@@ -196,13 +200,13 @@ sonarqube {
  * For mer info, se lenke under
  * https://opensource.expediagroup.com/graphql-kotlin/docs/plugins/gradle-plugin-usage#generating-multiple-clients
  */
-val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
+val generateSafGraphqlClient by tasks.getting(GraphQLGenerateClientTask::class) {
     queryFileDirectory.set(file("${project.projectDir}/src/main/resources/saf"))
     schemaFile.set(file("${project.projectDir}/src/main/resources/saf/saf-api-sdl.graphqls"))
     packageName.set("no.nav.sifinnsynapi.saf.generated")
 }
 
-val graphqlGenerateOtherClient by tasks.creating(GraphQLGenerateClientTask::class) {
+val generateSafSelvbetjeningGraphqlClient by tasks.creating(GraphQLGenerateClientTask::class) {
     queryFileDirectory.set(file("${project.projectDir}/src/main/resources/safselvbetjening"))
     schemaFile.set(file("${project.projectDir}/src/main/resources/safselvbetjening/saf-selvbetjening-sdl.graphqls"))
     packageName.set("no.nav.sifinnsynapi.safselvbetjening.generated")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.24"
-    kotlin("plugin.spring") version "1.9.24"
-    kotlin("plugin.jpa") version "1.9.24"
-    id("org.springframework.boot") version "3.2.5"
+    kotlin("jvm") version "2.0.0"
+    kotlin("plugin.spring") version "2.0.0"
+    kotlin("plugin.jpa") version "2.0.0"
+    id("org.springframework.boot") version "3.3.1"
     id("io.spring.dependency-management") version "1.1.5"
     id("com.expediagroup.graphql") version "7.1.1"
     id("org.sonarqube") version "5.0.0.4638"
@@ -23,9 +23,9 @@ configurations {
 }
 
 val confluentVersion = "7.6.1"
-val springCloudVersion = "4.1.2"
+val springCloudVersion = "4.1.3"
 val logstashLogbackEncoderVersion = "7.4"
-val tokenSupportVersion = "4.1.7"
+val tokenSupportVersion = "5.0.1"
 val retryVersion = "2.0.6"
 val zalandoVersion = "0.27.0"
 val openhtmltopdfVersion = "1.0.10"
@@ -35,7 +35,7 @@ val awailitilityKotlinVersion = "4.2.1"
 val assertkJvmVersion = "0.28.1"
 val springMockkVersion = "4.0.2"
 val mockkVersion = "1.13.11"
-val guavaVersion = "33.2.0-jre"
+val guavaVersion = "33.2.1-jre"
 val orgJsonVersion = "20240303"
 val graphQLKotlinVersion = "7.1.1"
 val k9FormatVersion = "8.3.4"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -61,13 +61,13 @@ application-ingress: http://localhost:9999
 
 spring:
   datasource:
-    url: jdbc:tc:postgresql:12:///
+    url: jdbc:tc:postgresql:14:///
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   flyway:
     enabled: true
   jpa:
     show-sql: true
-    database-platform: org.hibernate.dialect.PostgreSQL12Dialect
+    database-platform: org.hibernate.dialect.PostgreSQL14Dialect
 
 logging:
   level:


### PR DESCRIPTION
Bygg feiler fordi graphql client generator ikke støtter Spring Boot 3.3.x.
Versjon 8 vil støtte det. Tråd her: https://github.com/ExpediaGroup/graphql-kotlin/issues/1975 
Lukker #475 