### PR TITLE
Nytt bekreftelsesbrev til arbeidsgiver tilpasset inntektsmelding gjennom nav.no

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGenerator.kt
@@ -7,10 +7,10 @@ import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
 @Service
-class ArbeidsgiverMeldingPDFGenerator : PDFGenerator<PleiepengerArbeidsgiverMelding>() {
+class ArbeidsgiverMeldingNavNoPDFGenerator : PDFGenerator<PleiepengerArbeidsgiverMelding>() {
 
     override val templateNavn: String
-        get() = "informasjonsbrev-til-arbeidsgiver"
+        get() = "informasjonsbrev-til-arbeidsgiver-nav-no"
 
 
     override fun PleiepengerArbeidsgiverMelding.tilMap(): Map<String, Any?> = mapOf(

--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingPDFGenerator.kt
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Service
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
+@Deprecated(
+    "Etter at ny inntektsmelding gjennom nav.no er aktivert, ønsker vi ikke å bruke denne lenger",
+    ReplaceWith("ArbeidsgiverMeldingNavNoPDFGenerator")
+)
 @Service
 class ArbeidsgiverMeldingPDFGenerator : PDFGenerator<PleiepengerArbeidsgiverMelding>() {
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/PleiepengerArbeidsgiverMelding.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/PleiepengerArbeidsgiverMelding.kt
@@ -1,0 +1,7 @@
+package no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn
+
+data class PleiepengerArbeidsgiverMelding(
+    val arbeidstakernavn: String,
+    val arbeidsgivernavn: String? = null,
+    val søknadsperiode: SøknadsPeriode
+)

--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/SøknadsPeriode.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/SøknadsPeriode.kt
@@ -1,0 +1,8 @@
+package no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn
+
+import java.time.LocalDate
+
+data class SøknadsPeriode(
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate
+)

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
@@ -33,9 +33,8 @@ class SøknadService(
     private val dokumentService: DokumentService,
     private val arbeidsgiverMeldingPDFGenerator: ArbeidsgiverMeldingPDFGenerator,
     private val arbeidsgiverMeldingNavNoPDFGenerator: ArbeidsgiverMeldingNavNoPDFGenerator,
-    @Value("\${no.nav.inntektsmelding.ny-im-aktivert}") val erNyImAktivert: Boolean = false,
-
-    ) {
+    @Value("\${no.nav.inntektsmelding.ny-im-aktivert}") val erNyImAktivert: Boolean = false
+) {
 
     companion object {
         private val mapper = ObjectMapper()
@@ -118,12 +117,11 @@ class SøknadService(
                         )
                     )
                 } else {
-                arbeidsgiverMeldingPDFGenerator.genererPDF(
-                    pleiepengesøknadJson.tilPleiepengerAreidsgivermelding(
-                        funnetOrg
+                    arbeidsgiverMeldingPDFGenerator.genererPDF(
+                        pleiepengesøknadJson.tilPleiepengerAreidsgivermelding(
+                            funnetOrg
+                        )
                     )
-                )
-
                 }
             }
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
@@ -111,6 +111,7 @@ class SøknadService(
                 val funnetOrg: JSONObject = pleiepengesøknadJson.finnOrganisasjon(søknad, organisasjonsnummer)
 
                 if (erNyImAktivert) {
+                    logger.info("Ny inntektsmelding er aktivert, genererer PDF med nytt template.")
                     arbeidsgiverMeldingNavNoPDFGenerator.genererPDF(
                         pleiepengesøknadJson.tilPleiepengerAreidsgivermelding(
                             funnetOrg

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadService.kt
@@ -8,6 +8,7 @@ import no.nav.sifinnsynapi.common.Søknadstype
 import no.nav.sifinnsynapi.dokument.DokumentDTO
 import no.nav.sifinnsynapi.dokument.DokumentService
 import no.nav.sifinnsynapi.dokument.DokumentService.Companion.brevkoder
+import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.ArbeidsgiverMeldingNavNoPDFGenerator
 import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.ArbeidsgiverMeldingPDFGenerator
 import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.PleiepengerJSONObjectUtils.finnOrganisasjon
 import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.PleiepengerJSONObjectUtils.tilPleiepengerAreidsgivermelding
@@ -15,6 +16,7 @@ import no.nav.sifinnsynapi.oppslag.OppslagsService
 import no.nav.sifinnsynapi.util.ServletUtils
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.stereotype.Service
@@ -29,8 +31,11 @@ class SøknadService(
     private val repo: SøknadRepository,
     private val oppslagsService: OppslagsService,
     private val dokumentService: DokumentService,
-    private val arbeidsgiverMeldingPDFGenerator: ArbeidsgiverMeldingPDFGenerator
-) {
+    private val arbeidsgiverMeldingPDFGenerator: ArbeidsgiverMeldingPDFGenerator,
+    private val arbeidsgiverMeldingNavNoPDFGenerator: ArbeidsgiverMeldingNavNoPDFGenerator,
+    @Value("\${no.nav.inntektsmelding.ny-im-aktivert}") val erNyImAktivert: Boolean = false,
+
+    ) {
 
     companion object {
         private val mapper = ObjectMapper()
@@ -105,11 +110,20 @@ class SøknadService(
                 val pleiepengesøknadJson = JSONObject(søknad.søknad)
                 val funnetOrg: JSONObject = pleiepengesøknadJson.finnOrganisasjon(søknad, organisasjonsnummer)
 
+                if (erNyImAktivert) {
+                    arbeidsgiverMeldingNavNoPDFGenerator.genererPDF(
+                        pleiepengesøknadJson.tilPleiepengerAreidsgivermelding(
+                            funnetOrg
+                        )
+                    )
+                } else {
                 arbeidsgiverMeldingPDFGenerator.genererPDF(
                     pleiepengesøknadJson.tilPleiepengerAreidsgivermelding(
                         funnetOrg
                     )
                 )
+
+                }
             }
 
             else -> throw NotSupportedArbeidsgiverMeldingException(søknad.id.toString(), søknad.søknadstype)

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -39,6 +39,10 @@ no.nav:
     pleiepenger-sykt-barn:
       beskjed:
         link: https://sif-innsyn.intern.dev.nav.no/familie/sykdom-i-familien/soknad/innsyn
+
     pleiepenger-sykt-barn-endringsmelding:
       beskjed:
         link: https://sif-innsyn.intern.dev.nav.no/familie/sykdom-i-familien/soknad/innsyn
+
+    inntektsmelding:
+      ny-im-aktivert: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,9 @@ no.nav:
         tekst: 'Vi har mottatt din ettersendelse til omsorgspenger.'
         dagerSynlig: 7
 
+  inntektsmelding:
+    ny-im-aktivert: false
+
   gateways:
     k9-selvbetjening-oppslag: # Settes i nais/<cluster>.json
     saf-base-url: # Settes i nais/<cluster>.json

--- a/src/main/resources/handlebars/informasjonsbrev-til-arbeidsgiver-nav-no.hbs
+++ b/src/main/resources/handlebars/informasjonsbrev-til-arbeidsgiver-nav-no.hbs
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="NO">
+
+<head>
+    <meta charset="UTF-8"/>
+    <title>Bekreftelse til Arbeidsgiver</title>
+    <meta name="subject" content="Informasjonsbrev til Arbeidsgiver"/>
+    <meta name="author" content="nav.no"/>
+    <meta name="description" content="Bekreftelse til Arbeidsgiver {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
+    <bookmarks>
+        <bookmark name="Informasjon" href="#informasjon"/>
+        <bookmark name="Instruksjon" href="#instruksjon"/>
+    </bookmarks>
+    {{#block 'style-common' }}
+    {{/block}}
+</head>
+
+<body>
+<div class="innholdscontainer">
+    <span id="header"></span>
+
+    <section id="informasjon">
+        <h1>Til {{arbeidsgiver_navn}}</h1>
+        <p><strong>{{arbeidstaker_navn}}</strong> har søkt om pleiepenger for perioden</p>
+        <ul>
+            <li>
+                <strong>{{periode.fom}} - {{periode.tom}}</strong>
+            </li>
+        </ul>
+
+        <p>
+            Hvis vi trenger inntektsmelding for å behandle søknaden, vil du få varsel om dette via Altinn og på
+            Min side – arbeidsgiver på nav.no. Du kan da logge inn på nav.no for å sende inn en forhåndsutfylt
+            inntektsmelding.
+        </p>
+
+        <p>
+            Det er også mulig å sende inntektsmelding fra Altinn og lønns- og personalsystem, men du må da være
+            observant på at vi får riktig informasjon om første fraværsdag, organisasjonsnummer og eventuelt
+            arbeidsforholds-id.
+        </p>
+
+        <p>
+            Som hovedregel trenger vi inntektsmelding hvis dette er første søknad, eller hvis det har vært et
+            opphold på minst 4 uker. Hvis det har vært et kortere opphold mellom pleiepengeperiodene, der den
+            ansatte har hatt en varig lønnsendring, trenger vi også ny inntektsmelding.
+        </p>
+    </section>
+
+    <section id="spørsmål">
+        <h2>Har dere spørsmål?</h2>
+        <p>Dere finner mer informasjon på <a href="https://nav.no/arbeidsgiver">nav.no/arbeidsgiver</a></p>
+
+        <p>På <a href="https://nav.no/kontakt">nav.no/kontakt</a> kan dere chatte med oss.</p>
+
+        <p>Dere kan også ringe oss på telefon 55 55 33 36, hverdager 09.00-15.00.</p>
+    </section>
+</div>
+
+<!-- FOOTER -->
+<p id="footer">
+    <span class="tidspunkt">{{ tidspunkt }}</span>
+    <span class="sidetall">side <span id="pagenumber"></span> av <span id="pagecount"></span></span>
+</p>
+</body>
+
+</html>

--- a/src/test/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGeneratorTest.kt
@@ -1,0 +1,28 @@
+package no.nav.sifinnsynapi.pdf
+
+import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.ArbeidsgiverMeldingNavNoPDFGenerator
+import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.PleiepengerArbeidsgiverMelding
+import no.nav.sifinnsynapi.konsument.pleiepenger.syktbarn.SøknadsPeriode
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDate
+
+class ArbeidsgiverMeldingNavNoPDFGeneratorTest {
+
+    @Test
+    fun pdf() {
+        val pdf = ArbeidsgiverMeldingNavNoPDFGenerator().genererPDF(
+            melding = PleiepengerArbeidsgiverMelding(
+                arbeidstakernavn = "Ola Nordmann",
+                arbeidsgivernavn = "Sjokkerende Elektriker",
+                søknadsperiode = SøknadsPeriode(
+                    fraOgMed = LocalDate.now().minusWeeks(1),
+                    tilOgMed = LocalDate.now().plusWeeks(1)
+                )
+            )
+        )
+        File(pdfPath("Bekreftelse til arbeidsgiver")).writeBytes(pdf)
+    }
+
+    private fun pdfPath(filnavn: String) = "${System.getProperty("user.dir")}/generated-pdf-$filnavn.pdf"
+}


### PR DESCRIPTION
## Bakgrunn
I forbindelse med ny inntektsmelding gjennom nav.no som først skal tas i bruk for pleiepenger, ønsker vi å informere arbeidsgiver om at de kan sende inn inntektsmelding der. 

Jira oppgave: https://jira.adeo.no/browse/TSFF-1039

## Løsning
* Har tatt utgangspunkt i den eksisterende `ArbeidsgiverMeldingPDFGenerator` og lagd en tilsvarende `ArbeidsgiverMeldingNavNoPDFGenerator` som henter riktig brevmal.
* Lagt til feature toggle som styres fra `SøknadService`.

## Notat
Tilsvarende må gjøres i `k9-sak-innsyn-api`.

## Bilder
|  Beskrivelse av brevet | Det genererte brevet |
| ------------- | ------------- |
| ![Screenshot 2025-01-14 at 17 23 20](https://github.com/user-attachments/assets/47d9eb41-ef17-4d74-85b9-ff2be04ee3df)  | ![Screenshot 2025-01-14 at 17 30 11](https://github.com/user-attachments/assets/49b68669-a3e1-4d66-b015-8a707edecbf5) |






