### PR TITLE
Update build.gradle.kts med nyeste teamdokumenthandtering-avro-schemas

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ val guavaVersion = "33.4.8-jre"
 val orgJsonVersion = "20250517"
 val graphQLKotlinVersion = "8.8.1"
 val k9FormatVersion = "12.3.2"
-val teamDokumenthåndteringAvroSchemaVersion = "08271806"
+val teamDokumenthåndteringAvroSchemaVersion = "1.1.6"
 val testContainersVersion = "1.21.3"
 val springdocVersion = "2.8.9"
 


### PR DESCRIPTION
Hei! Dere bruker en gammel versjon av teamdokumenthandtering-avro-schemas. Vi brukte tidligere git short hash til å identifisere versjon, men dette skaper krøll for Dependabot som ikke forstår hva som er nyeste versjon. Vi har gått over til semver og vil at dere oppdaterer slik at vi kan slette de gamle releasene og Dependabot foreslår riktig versjon for oppdateringer.
Kan dere sjekke at oppdatering til siste versjon av teamdokumenthandtering-avro-schemas går fint og ta det i bruk?