### PR TITLE
Downgrade Spring boot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.spring") version "2.3.20"
     kotlin("plugin.jpa") version "2.3.20"
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.3"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.expediagroup.graphql") version "9.1.0"
     id("org.sonarqube") version "7.2.3.7755"


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ny version av spring boot gjør at vi bruker jackson 3, noe vi ikke er rigget for helt ennå.

### **Løsning**
Downgrader, tilsvarende som https://github.com/navikt/k9-sak-innsyn-api/pull/503
