### PR TITLE
Fiks: Pin tomcat version to 11.0.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ group = "no.nav"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_25
 
+extra["tomcat.version"] = "11.0.21"
+
 configurations {
     compileOnly {
         extendsFrom(configurations.annotationProcessor.get())


### PR DESCRIPTION
### **Behov / Bakgrunn**
Tomcat har en kritisk sårbarhet. Den er egentlig bundlet med spring boot, men vi må vente med å oppgraderer spring til jackson feilen er håndtert. 

### **Løsning**
Midlertidig fiks: pin tomcat versjonen.