### PR TITLE
Erstatter ikke-godkjente fødselsnummer med fiktive FNR fra godkjent liste

### DIFF
--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadServiceTest.kt
@@ -74,7 +74,7 @@ internal class SøknadServiceTest {
                 status = SøknadsStatus.MOTTATT,
                 journalpostId = "123456789",
                 opprettet = ZonedDateTime.parse("2020-08-04T10:30:00Z").withZoneSameInstant(ZoneId.of("UTC")),
-                fødselsnummer = Fødselsnummer("02119970078"),
+                fødselsnummer = Fødselsnummer("01017000299"),
                 aktørId = AktørId("123456"),
                 søknad =
                 //language=json
@@ -86,7 +86,7 @@ internal class SøknadServiceTest {
                                   "mellomnavn": "Mellomnavn",
                                   "etternavn": "Nordmann",
                                   "aktørId": "123456",
-                                  "fødselsnummer": "02119970078",
+                                  "fødselsnummer": "01017000299",
                                   "fornavn": "Ola"
                                 },
                                 "arbeidsgivere": {
@@ -129,7 +129,7 @@ internal class SøknadServiceTest {
                 status = SøknadsStatus.MOTTATT,
                 journalpostId = "123456789",
                 opprettet = ZonedDateTime.parse("2020-08-04T10:30:00Z").withZoneSameInstant(ZoneId.of("UTC")),
-                fødselsnummer = Fødselsnummer("02119970078"),
+                fødselsnummer = Fødselsnummer("01017000299"),
                 aktørId = AktørId("123456"),
                 søknad =
                 //language=json
@@ -141,7 +141,7 @@ internal class SøknadServiceTest {
                     "mellomnavn": "Mellomnavn",
                     "etternavn": "Nordmann",
                     "aktørId": "123456",
-                    "fødselsnummer": "02119970078",
+                    "fødselsnummer": "01017000299",
                     "fornavn": "Ola"
                   },
                   "arbeidsgivere": [
@@ -181,7 +181,7 @@ internal class SøknadServiceTest {
                 status = SøknadsStatus.MOTTATT,
                 journalpostId = "123456789",
                 opprettet = ZonedDateTime.parse("2020-08-04T10:30:00Z").withZoneSameInstant(ZoneId.of("UTC")),
-                fødselsnummer = Fødselsnummer("02119970078"),
+                fødselsnummer = Fødselsnummer("01017000299"),
                 aktørId = AktørId("123456"),
                 søknad =
                 //language=json


### PR DESCRIPTION
## Erstatter ikke-godkjente fødselsnummer

Bytter ut fødselsnummer som ikke er på [godkjent liste](https://github.com/navikt/sif-gha-workflows/tree/main/.github/actions/sif-code-scan/allowed-fnr) med fiktive fødselsnummer fra sif-gha-workflows allowed-fnr.

Dette sikrer at `sif-code-scan` ikke feiler i CI/CD-pipeline.