### PR TITLE
Omdøper navn til Barn -> BarnOpplysninger for å rette Swagger-skjema for /innsyn/sak

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynApiService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/k9sakinnsynapi/K9SakInnsynApiService.kt
@@ -76,11 +76,11 @@ class K9SakInnsynApiService(
 }
 
 data class K9SakInnsynSøknad(
-    val barn: Barn,
+    val barn: BarnOpplysninger,
     val søknad: Søknad
 )
 
-data class Barn(
+data class BarnOpplysninger(
     val fødselsdato: LocalDate,
     val fornavn: String,
     val mellomnavn: String? = null,


### PR DESCRIPTION
Navnekonflikt mellom lokal `Barn`-klasse og `Barn` fra det eksterne `no.nav.k9.søknad`-biblioteket førte til at Swagger viste feil skjema for barn-feltet i responsen. Løst ved å gi den lokale klassen et unikt navn: `BarnOpplysninger`.